### PR TITLE
Work item for migrating “Java 8 Nashorn CLI use case: prepending ISO instant to CSV from UNIX timestamp”.

### DIFF
--- a/_posts/2017-08-07-migrate-nashorn-cli-use-case-article.md
+++ b/_posts/2017-08-07-migrate-nashorn-cli-use-case-article.md
@@ -5,4 +5,4 @@ skills: [ html, indieweb, semantic ]
 layout: post
 ---
 
-- Issue: [https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55](https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55)
+- Issue: [https://github.com/ScalaWilliam/ScalaWilliam.com/issues/87](https://github.com/ScalaWilliam/ScalaWilliam.com/issues/87)

--- a/_posts/2017-08-07-migrate-nashorn-cli-use-case-article.md
+++ b/_posts/2017-08-07-migrate-nashorn-cli-use-case-article.md
@@ -1,0 +1,8 @@
+---
+price: "$20"
+title: "Migrate article: Java 8 Nashorn CLI use case: prepending ISO instant to CSV from UNIX timestamp, Jan 2017"
+skills: [ html, indieweb, semantic ]
+layout: post
+---
+
+- Issue: [https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55](https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55)


### PR DESCRIPTION
Work item for migrating “Java 8 Nashorn CLI use case: prepending ISO instant to CSV from UNIX timestamp” from Medium.

Links simply to ScalaWilliam/ScalaWilliam.com#55 as the separate issues before didn’t add anything. Also because there is already a PR ready to go.