### PR TITLE
Work item for migrating “2017 freelance development platforms”.

### DIFF
--- a/_posts/2017-08-07-2017-freelance-development-platforms-article.md
+++ b/_posts/2017-08-07-2017-freelance-development-platforms-article.md
@@ -1,0 +1,8 @@
+---
+price: "$5"
+title: "Migrate article: 2017 freelance development platforms, Apr 2017"
+skills: [ html, indieweb, semantic ]
+layout: post
+---
+
+- Issue: [https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55](https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55)

--- a/_posts/2017-08-07-2017-freelance-development-platforms-article.md
+++ b/_posts/2017-08-07-2017-freelance-development-platforms-article.md
@@ -5,4 +5,4 @@ skills: [ html, indieweb, semantic ]
 layout: post
 ---
 
-- Issue: [https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55](https://github.com/ScalaWilliam/ScalaWilliam.com/issues/55)
+- Issue: [https://github.com/ScalaWilliam/ScalaWilliam.com/issues/85](https://github.com/ScalaWilliam/ScalaWilliam.com/issues/85)


### PR DESCRIPTION
Work item for migrating “2017 freelance development platforms” from The Practical Dev.

Links simply to ScalaWilliam/ScalaWilliam.com#55 as the separate issues before didn’t add anything. Also because there is already a PR ready to go.